### PR TITLE
chore: make compatible with stable branch of flutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ doc/api/
 
 .flutter-plugins
 .flutter-plugins-dependencies
+
+.idea/

--- a/packages/pmtiles/pubspec.yaml
+++ b/packages/pmtiles/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   http: ^1.1.0
-  meta: ^1.11.0
+  meta: ^1.10.0
   path: ^1.8.3
 
   # latlong2 is maybe overkill, but anyone consuming this package is most likely already using it.


### PR DESCRIPTION
Thanks for this amazing package Andrew!
I tried to use it in flutter but had dependency conflicts on the stable flutter branch because this package restricts meta to be `^1.11.0` but the flutter sdk has it set to `1.10.0`.

This conflict can be reproduced with:
```yaml
dependencies:
  flutter:
    sdk: flutter
```

Console error:
```console
C:\dev\flutter\bin\flutter.bat --no-color pub upgrade
Resolving dependencies...
Note: meta is pinned to version 1.10.0 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because pmtiles depends on flutter from sdk which depends on meta 1.10.0, meta 1.10.0 is required.
So, because pmtiles depends on meta ^1.11.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on meta: flutter pub add meta:^1.10.0
Process finished with exit code 1
```

This pull request just loosens the constrain to be `^1.10.0`. This should have no impact on the pacakge itself because it doesn't uses `TargetKind.extensionType` that was introduced in `meta` version 1.11.

Another tiny change: I allowed myself to add Jetbrains `.idea` directory to the .gitignore file.